### PR TITLE
Rename "current angular velocity" to "angular velocity"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -16,7 +16,7 @@ Version History: https://github.com/w3c/gyroscope/commits/gh-pages/index.bs
 Indent: 2
 Repository: w3c/gyroscope
 Markup Shorthands: markdown on
-Inline Github Issues: title
+Inline Github Issues: true
 !Test Suite: <a href="https://github.com/w3c/web-platform-tests/tree/master/gyroscope">web-platform-tests on GitHub</a>
 Boilerplate: omit issues-index, omit conformance
 Default Biblio Status: current
@@ -71,13 +71,13 @@ The gyroscope's associated {{Sensor}} subclass is the {{Gyroscope}} class.
 Gyroscope has a <a>default sensor</a>, which is the device's main gyroscope sensor.
 
 A [=latest reading=] per [=sensor=] of gyroscope type includes three [=map/entries=]
-whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain <a>current angular
+whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain current <a>angular
 velocity</a> about the corresponding axes.
 
-The <dfn>current angular velocity</dfn> is the rate at which the device rotates
+The <dfn>angular velocity</dfn> is the rate at which the device rotates
 about a specified axis. Its unit is the radian per second (rad/s) [[SI]].
 
-The sign of the <a>current angular velocity</a> depends on the rotation direction and
+The sign of the current <a>angular velocity</a> depends on the rotation direction and
 it must be according to the right-hand convention, such that positive rotation around
 an axis is clockwise when viewed along the positive direction of the axis (see figure below).
 
@@ -105,19 +105,19 @@ To <dfn>Construct a Gyroscope Object</dfn> the user agent must invoke the
 ### Gyroscope.x ### {#gyroscope-x}
 
 The {{Gyroscope/x!!attribute}} attribute of the {{Gyroscope}}
-interface represents the <a>current angular velocity</a> around X-axis.
+interface represents the current <a>angular velocity</a> around X-axis.
 In other words, this attribute returns [=latest reading=]["x"].
 
 ### Gyroscope.y ### {#gyroscope-y}
 
 The {{Gyroscope/y!!attribute}} attribute of the {{Gyroscope}}
-interface represents the <a>current angular velocity</a> around Y-axis.
+interface represents the current <a>angular velocity</a> around Y-axis.
 In other words, this attribute returns [=latest reading=]["y"].
 
 ### Gyroscope.z ### {#gyroscope-z}
 
 The {{Gyroscope/z!!attribute}} attribute of the {{Gyroscope}}
-interface represents the <a>current angular velocity</a> around Z-axis.
+interface represents the current <a>angular velocity</a> around Z-axis.
 In other words, this attribute returns [=latest reading=]["z"].
 
 Acknowledgements {#acknowledgements}

--- a/index.html
+++ b/index.html
@@ -419,7 +419,7 @@
 	[data-algorithm]:not(.heading) {
 	  padding: .5em;
 	  border: thin solid #ddd; border-radius: .5em;
-	  margin: .5em 0;
+	  margin: .5em calc(-0.5em - 1px);
 	}
 	[data-algorithm]:not(.heading) > :first-child {
 	  margin-top: 0;
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 009836c46217067220542eccc715a300175723d6" name="generator">
+  <meta content="Bikeshed version a65093ce3e69a8d01029b4650499d152cd9bd39a" name="generator">
 <style>/* style-md-lists */
 
             /* This is a weird hack for me not yet following the commonmark spec
@@ -1428,9 +1428,9 @@ pre.idl.highlight { color: #708090; }
         </style>
  <body class="h-entry">
   <div class="head">
-   <p data-fill-with="logo"><a class="logo" href="http://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
+   <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Gyroscope</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-01-31">31 January 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-03-15">15 March 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1480,7 +1480,7 @@ the rate of rotation around the device’s local three primary axes.</p>
 	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/43696/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
 	An individual who has actual knowledge of a patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="http://www.w3.org/2015/Process-20150901/" id="w3c_process_revision">1 September 2015 W3C Process Document</a>. </p>
+   <p> This document is governed by the <a href="https://www.w3.org/2017/Process-20170301/" id="w3c_process_revision">1 March 2017 W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -1544,11 +1544,11 @@ beyond those described in the Generic Sensor API <a data-link-type="biblio" href
    <h2 class="heading settled" data-level="4" id="model"><span class="secno">4. </span><span class="content">Model</span><a class="self-link" href="#model"></a></h2>
    <p>The gyroscope’s associated <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor">Sensor</a></code> subclass is the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope-1">Gyroscope</a></code> class.</p>
    <p>Gyroscope has a <a data-link-type="dfn" href="https://w3c.github.io/sensors#default-sensor">default sensor</a>, which is the device’s main gyroscope sensor.</p>
-   <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a> per <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor">sensor</a> of gyroscope type includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">values</a> contain <a data-link-type="dfn" href="#current-angular-velocity" id="ref-for-current-angular-velocity-1">current angular
+   <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a> per <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor">sensor</a> of gyroscope type includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value">values</a> contain current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity-1">angular
 velocity</a> about the corresponding axes.</p>
-   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="current-angular-velocity">current angular velocity</dfn> is the rate at which the device rotates
+   <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="angular-velocity">angular velocity</dfn> is the rate at which the device rotates
 about a specified axis. Its unit is the radian per second (rad/s) <a data-link-type="biblio" href="#biblio-si">[SI]</a>.</p>
-   <p>The sign of the <a data-link-type="dfn" href="#current-angular-velocity" id="ref-for-current-angular-velocity-2">current angular velocity</a> depends on the rotation direction and
+   <p>The sign of the current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity-2">angular velocity</a> depends on the rotation direction and
 it must be according to the right-hand convention, such that positive rotation around
 an axis is clockwise when viewed along the positive direction of the axis (see figure below).</p>
    <p><img alt="Device’s local coordinate system and rotation." src="gyroscope_sensor_coordinate_system.png" srcset="gyroscope_sensor_coordinate_system.svg"></p>
@@ -1556,20 +1556,20 @@ an axis is clockwise when viewed along the positive direction of the axis (see f
    <h3 class="heading settled" data-level="5.1" id="gyroscope-interface"><span class="secno">5.1. </span><span class="content">The Gyroscope Interface</span><a class="self-link" href="#gyroscope-interface"></a></h3>
 <pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="Gyroscope" data-dfn-type="constructor" data-export="" data-lt="Gyroscope(sensorOptions)|Gyroscope()" id="dom-gyroscope-gyroscope">Constructor<a class="self-link" href="#dom-gyroscope-gyroscope"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="Gyroscope/Gyroscope(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-gyroscope-gyroscope-sensoroptions-sensoroptions">sensorOptions<a class="self-link" href="#dom-gyroscope-gyroscope-sensoroptions-sensoroptions"></a></dfn>)]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="gyroscope">Gyroscope</dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Gyroscope" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-gyroscope-x">x</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Gyroscope" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-gyroscope-y">y</dfn>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Gyroscope" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-gyroscope-z">z</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Gyroscope" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-gyroscope-x">x</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Gyroscope" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-gyroscope-y">y</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Gyroscope" data-dfn-type="attribute" data-export="" data-readonly="" data-type="unrestricted double?" id="dom-gyroscope-z">z</dfn>;
 };
 </pre>
    <p>To <dfn data-dfn-type="dfn" data-noexport="" id="construct-a-gyroscope-object">Construct a Gyroscope Object<a class="self-link" href="#construct-a-gyroscope-object"></a></dfn> the user agent must invoke the <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object">construct a Sensor object</a> abstract operation.</p>
    <h4 class="heading settled" data-level="5.1.1" id="gyroscope-x"><span class="secno">5.1.1. </span><span class="content">Gyroscope.x</span><a class="self-link" href="#gyroscope-x"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-gyroscope-x" id="ref-for-dom-gyroscope-x-1">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope-2">Gyroscope</a></code> interface represents the <a data-link-type="dfn" href="#current-angular-velocity" id="ref-for-current-angular-velocity-3">current angular velocity</a> around X-axis.
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-gyroscope-x" id="ref-for-dom-gyroscope-x-1">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope-2">Gyroscope</a></code> interface represents the current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity-3">angular velocity</a> around X-axis.
 In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["x"].</p>
    <h4 class="heading settled" data-level="5.1.2" id="gyroscope-y"><span class="secno">5.1.2. </span><span class="content">Gyroscope.y</span><a class="self-link" href="#gyroscope-y"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-gyroscope-y" id="ref-for-dom-gyroscope-y-1">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope-3">Gyroscope</a></code> interface represents the <a data-link-type="dfn" href="#current-angular-velocity" id="ref-for-current-angular-velocity-4">current angular velocity</a> around Y-axis.
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-gyroscope-y" id="ref-for-dom-gyroscope-y-1">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope-3">Gyroscope</a></code> interface represents the current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity-4">angular velocity</a> around Y-axis.
 In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["y"].</p>
    <h4 class="heading settled" data-level="5.1.3" id="gyroscope-z"><span class="secno">5.1.3. </span><span class="content">Gyroscope.z</span><a class="self-link" href="#gyroscope-z"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-gyroscope-z" id="ref-for-dom-gyroscope-z-1">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope-4">Gyroscope</a></code> interface represents the <a data-link-type="dfn" href="#current-angular-velocity" id="ref-for-current-angular-velocity-5">current angular velocity</a> around Z-axis.
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-gyroscope-z" id="ref-for-dom-gyroscope-z-1">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope-4">Gyroscope</a></code> interface represents the current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity-5">angular velocity</a> around Z-axis.
 In other words, this attribute returns <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading">latest reading</a>["z"].</p>
    <h2 class="heading settled" data-level="6" id="acknowledgements"><span class="secno">6. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
    <p>Tobie Langel for the work on Generic Sensor API.</p>
@@ -1592,9 +1592,9 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h2 class="no-num no-ref heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
   <h3 class="no-num no-ref heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
   <ul class="index">
+   <li><a href="#angular-velocity">angular velocity</a><span>, in §4</span>
    <li><a href="#conformant-user-agent">conformant user agent</a><span>, in §7</span>
    <li><a href="#construct-a-gyroscope-object">Construct a Gyroscope Object</a><span>, in §5.1</span>
-   <li><a href="#current-angular-velocity">current angular velocity</a><span>, in §4</span>
    <li><a href="#dom-gyroscope-gyroscope">Gyroscope()</a><span>, in §5.1</span>
    <li><a href="#gyroscope">Gyroscope</a><span>, in §5.1</span>
    <li><a href="#dom-gyroscope-gyroscope">Gyroscope(sensorOptions)</a><span>, in §5.1</span>
@@ -1625,18 +1625,23 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="https://infra.spec.whatwg.org/#map-key">key</a>
      <li><a href="https://infra.spec.whatwg.org/#map-value">value</a>
     </ul>
+   <li>
+    <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
+    <ul>
+     <li><a href="https://heycam.github.io/webidl/#idl-unrestricted-double">unrestricted double</a>
+    </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
    <dt id="biblio-generic-sensor">[GENERIC-SENSOR]
-   <dd>Tobie Langel; Rick Waldron. <a href="https://w3c.github.io/sensors/">Generic Sensor API</a>. URL: <a href="https://w3c.github.io/sensors/">https://w3c.github.io/sensors/</a>
+   <dd>Tobie Langel; Rick Waldron. <a href="https://www.w3.org/TR/generic-sensor/">Generic Sensor API</a>. URL: <a href="https://www.w3.org/TR/generic-sensor/">https://www.w3.org/TR/generic-sensor/</a>
    <dt id="biblio-infra">[INFRA]
    <dd>Anne van Kesteren; Domenic Denicola. <a href="https://infra.spec.whatwg.org/">Infra Standard</a>. Living Standard. URL: <a href="https://infra.spec.whatwg.org/">https://infra.spec.whatwg.org/</a>
    <dt id="biblio-rfc2119">[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-webidl">[WEBIDL]
-   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://heycam.github.io/webidl/">Web IDL</a>. URL: <a href="https://heycam.github.io/webidl/">https://heycam.github.io/webidl/</a>
+   <dd>Cameron McCormack; Boris Zbarsky; Tobie Langel. <a href="https://www.w3.org/TR/WebIDL-1/">Web IDL</a>. URL: <a href="https://www.w3.org/TR/WebIDL-1/">https://www.w3.org/TR/WebIDL-1/</a>
   </dl>
   <h3 class="no-num no-ref heading settled" id="informative"><span class="content">Informative References</span><a class="self-link" href="#informative"></a></h3>
   <dl>
@@ -1646,19 +1651,19 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl def">[<a class="nv" href="#dom-gyroscope-gyroscope">Constructor</a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a> <a class="nv" href="#dom-gyroscope-gyroscope-sensoroptions-sensoroptions">sensorOptions</a>)]
 <span class="kt">interface</span> <a class="nv" href="#gyroscope">Gyroscope</a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor">Sensor</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-gyroscope-x">x</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-gyroscope-y">y</a>;
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">unrestricted</span> <span class="kt">double</span>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-gyroscope-z">z</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-gyroscope-x">x</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-gyroscope-y">y</a>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-unrestricted-double"><span class="kt">unrestricted</span> <span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="unrestricted double?" href="#dom-gyroscope-z">z</a>;
 };
 
 </pre>
-  <aside class="dfn-panel" data-for="current-angular-velocity">
-   <b><a href="#current-angular-velocity">#current-angular-velocity</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="angular-velocity">
+   <b><a href="#angular-velocity">#angular-velocity</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-current-angular-velocity-1">4. Model</a> <a href="#ref-for-current-angular-velocity-2">(2)</a>
-    <li><a href="#ref-for-current-angular-velocity-3">5.1.1. Gyroscope.x</a>
-    <li><a href="#ref-for-current-angular-velocity-4">5.1.2. Gyroscope.y</a>
-    <li><a href="#ref-for-current-angular-velocity-5">5.1.3. Gyroscope.z</a>
+    <li><a href="#ref-for-angular-velocity-1">4. Model</a> <a href="#ref-for-angular-velocity-2">(2)</a>
+    <li><a href="#ref-for-angular-velocity-3">5.1.1. Gyroscope.x</a>
+    <li><a href="#ref-for-angular-velocity-4">5.1.2. Gyroscope.y</a>
+    <li><a href="#ref-for-angular-velocity-5">5.1.3. Gyroscope.z</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="gyroscope">


### PR DESCRIPTION
This PR renames "current angular velocity" definition to "angular velocity", so that it would be easier to cross-reference physical definition from other specifications.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/alexshalamov/gyroscope/rename-definition.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/gyroscope/69660ab...alexshalamov:fcf32b1.html)