### PR TITLE
Previous Version bump for WD publication

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5,7 +5,7 @@ Level: none
 ED: https://w3c.github.io/gyroscope/
 Shortname: gyroscope
 TR: http://www.w3.org/TR/gyroscope/
-Previous Version: https://www.w3.org/TR/2017/WD-gyroscope-20170418/
+Previous Version: https://www.w3.org/TR/2017/WD-gyroscope-20170814/
 Editor: Anssi Kostiainen 41974, Intel Corporation, http://intel.com/
 Editor: Mikhail Pozdnyakov 78325, Intel Corporation, http://intel.com/
 Group: dap

--- a/index.html
+++ b/index.html
@@ -1183,8 +1183,9 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version ba473502a120361710488ab9b7f538b47858631e" name="generator">
+  <meta content="Bikeshed version 2d63ad75df4c3282ed7d8d3fb42b0c483a131ce1" name="generator">
   <link href="http://www.w3.org/TR/gyroscope/" rel="canonical">
+  <meta content="864859c4ee068acd434ceb211504b6905a57fdad" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1431,7 +1432,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Gyroscope</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-16">16 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-18">18 October 2017</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1439,7 +1440,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
      <dt>Latest published version:
      <dd><a href="http://www.w3.org/TR/gyroscope/">http://www.w3.org/TR/gyroscope/</a>
      <dt>Previous Versions:
-     <dd><a href="https://www.w3.org/TR/2017/WD-gyroscope-20170418/" rel="prev">https://www.w3.org/TR/2017/WD-gyroscope-20170418/</a>
+     <dd><a href="https://www.w3.org/TR/2017/WD-gyroscope-20170814/" rel="prev">https://www.w3.org/TR/2017/WD-gyroscope-20170814/</a>
      <dt>Version History:
      <dd><a href="https://github.com/w3c/gyroscope/commits/gh-pages/index.bs">https://github.com/w3c/gyroscope/commits/gh-pages/index.bs</a>
      <dt>Feedback:


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/gyroscope/previous-version.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/gyroscope/864859c...42c2e07.html)