### PR TITLE
Gyroscope can use the screen local coordinates

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -29,8 +29,15 @@ urlPrefix: https://w3c.github.io/sensors; spec: GENERIC-SENSOR
     text: sensor
     text: latest reading
     text: default sensor
-    text: construct a sensor object; url: construct-sensor-object
     text: sensor type
+    text: local coordinate system
+urlPrefix: https://w3c.github.io/accelerometer; spec: ACCELEROMETER
+  type: dfn
+    text: device coordinate system
+    text: screen coordinate system
+    text: construct spatial sensor object
+  type: interface
+    text: SpatialSensorOptions; url: dictdef-spatialsensoroptions
 </pre>
 
 Introduction {#intro}
@@ -92,11 +99,16 @@ it must be according to the right-hand convention in a [=local coordinate system
 defined by the device, such that positive rotation around an axis is clockwise when
 viewed along the positive direction of the axis (see figure below).
 
-Note: The <dfn>local coordinate system</dfn> of a mobile device is usually defined relative to
-the device's screen when the device in its default orientation (see figure below).
-
 <img src="images/gyroscope_sensor_coordinate_system.png" srcset="images/gyroscope_sensor_coordinate_system.svg" alt="Device's local coordinate system and rotation.">
 
+
+Reference Frame {#reference-frame}
+----------------
+
+The reference frame for {{Gyroscope}} is defined with
+a [=local coordinate system=], which can be defined as
+either the [=device coordinate system=], or the
+[=screen coordinate system=].
 
 API {#api}
 ===
@@ -105,7 +117,7 @@ The Gyroscope Interface {#gyroscope-interface}
 --------------------------------
 
 <pre class="idl">
-  [Constructor(optional SensorOptions sensorOptions), SecureContext, Exposed=Window]
+  [Constructor(optional SpatialSensorOptions sensorOptions), SecureContext, Exposed=Window]
   interface Gyroscope : Sensor {
     readonly attribute double? x;
     readonly attribute double? y;
@@ -113,8 +125,8 @@ The Gyroscope Interface {#gyroscope-interface}
   };
 </pre>
 
-To <dfn>Construct a Gyroscope Object</dfn> the user agent must invoke the 
-<a>construct a Sensor object</a> abstract operation.
+To <dfn>Construct a Gyroscope Object</dfn> the user agent must invoke
+the [=construct spatial sensor object=] abstract operation.
 
 ### Gyroscope.x ### {#gyroscope-x}
 

--- a/index.html
+++ b/index.html
@@ -1183,9 +1183,8 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 2d63ad75df4c3282ed7d8d3fb42b0c483a131ce1" name="generator">
+  <meta content="Bikeshed version 166744eb86a34dbc5493268ea410dc65275aa964" name="generator">
   <link href="http://www.w3.org/TR/gyroscope/" rel="canonical">
-  <meta content="864859c4ee068acd434ceb211504b6905a57fdad" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1432,7 +1431,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Gyroscope</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2017-10-18">18 October 2017</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-07">7 February 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1457,7 +1456,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2018 <a href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a> rules apply. </p>
    <hr title="Separator for header">
   </div>
   <div class="p-summary" data-fill-with="abstract">
@@ -1480,11 +1479,11 @@ the rate of rotation around the device’s local three primary axes.</p>
 	All comments are welcome. </p>
    <p> This document was produced by the <a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a>. </p>
    <p> This document was produced by a group operating under
-	the <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004 W3C Patent Policy</a>.
+	the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
 	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/43696/status" rel="disclosure">public list of any patent disclosures</a> made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
-	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
-   <p> This document is governed by the <a href="https://www.w3.org/2017/Process-20170301/" id="w3c_process_revision">1 March 2017 W3C Process Document</a>. </p>
+	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy/#def-essential">Essential Claim(s)</a> must disclose the information in accordance with <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">section 6 of the W3C Patent Policy</a>. </p>
+   <p> This document is governed by the <a href="https://www.w3.org/2018/Process-20180201/" id="w3c_process_revision">1 February 2018 W3C Process Document</a>. </p>
    <p></p>
   </div>
   <div data-fill-with="at-risk"></div>
@@ -1495,7 +1494,11 @@ the rate of rotation around the device’s local three primary axes.</p>
     <li><a href="#usecases-requirements"><span class="secno">2</span> <span class="content">Use Cases and Requirements</span></a>
     <li><a href="#examples"><span class="secno">3</span> <span class="content">Examples</span></a>
     <li><a href="#security-and-privacy"><span class="secno">4</span> <span class="content">Security and Privacy Considerations</span></a>
-    <li><a href="#model"><span class="secno">5</span> <span class="content">Model</span></a>
+    <li>
+     <a href="#model"><span class="secno">5</span> <span class="content">Model</span></a>
+     <ol class="toc">
+      <li><a href="#reference-frame"><span class="secno">5.1</span> <span class="content">Reference Frame</span></a>
+     </ol>
     <li>
      <a href="#api"><span class="secno">6</span> <span class="content">API</span></a>
      <ol class="toc">
@@ -1555,32 +1558,35 @@ beyond those described in the Generic Sensor API <a data-link-type="biblio" href
    <p>A <a data-link-type="dfn" href="https://w3c.github.io/sensors#latest-reading" id="ref-for-latest-reading">latest reading</a> of a <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor①">Sensor</a></code> of <a data-link-type="dfn" href="#gyroscope-sensor-type" id="ref-for-gyroscope-sensor-type②">Gyroscope</a> <a data-link-type="dfn" href="https://w3c.github.io/sensors#sensor-type" id="ref-for-sensor-type①">sensor type</a> includes three <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-entry" id="ref-for-map-entry">entries</a> whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-key" id="ref-for-map-key">keys</a> are "x", "y", "z" and whose <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#map-value" id="ref-for-map-value">values</a> contain current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity">angular
 velocity</a> about the corresponding axes.</p>
    <p>The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="angular-velocity">angular velocity</dfn> is the rate at which the device rotates
-about a specified axis in a <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> defined by the device.
+about a specified axis in a <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system">local coordinate system</a> defined by the device.
 Its unit is the radian per second (rad/s) <a data-link-type="biblio" href="#biblio-si">[SI]</a>.</p>
    <p>The sign of the current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity①">angular velocity</a> depends on the rotation direction and
-it must be according to the right-hand convention in a <a data-link-type="dfn" href="#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate system</a> defined by the device, such that positive rotation around an axis is clockwise when
+it must be according to the right-hand convention in a <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system①">local coordinate system</a> defined by the device, such that positive rotation around an axis is clockwise when
 viewed along the positive direction of the axis (see figure below).</p>
-   <p class="note" role="note"><span>Note:</span> The <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="local-coordinate-system">local coordinate system</dfn> of a mobile device is usually defined relative to
-the device’s screen when the device in its default orientation (see figure below).</p>
    <p><img alt="Device’s local coordinate system and rotation." src="images/gyroscope_sensor_coordinate_system.png" srcset="images/gyroscope_sensor_coordinate_system.svg"></p>
+   <h3 class="heading settled" data-level="5.1" id="reference-frame"><span class="secno">5.1. </span><span class="content">Reference Frame</span><a class="self-link" href="#reference-frame"></a></h3>
+   <p>The reference frame for <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope①">Gyroscope</a></code> is defined with
+a <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system②">local coordinate system</a>, which can be defined as
+either the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system">device coordinate system</a>, or the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system">screen coordinate system</a>.</p>
    <h2 class="heading settled" data-level="6" id="api"><span class="secno">6. </span><span class="content">API</span><a class="self-link" href="#api"></a></h2>
    <h3 class="heading settled" data-level="6.1" id="gyroscope-interface"><span class="secno">6.1. </span><span class="content">The Gyroscope Interface</span><a class="self-link" href="#gyroscope-interface"></a></h3>
-<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="Gyroscope" data-dfn-type="constructor" data-export="" data-lt="Gyroscope(sensorOptions)|Gyroscope()" id="dom-gyroscope-gyroscope"><code>Constructor</code><a class="self-link" href="#dom-gyroscope-gyroscope"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions">SensorOptions</a> <dfn class="nv idl-code" data-dfn-for="Gyroscope/Gyroscope(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-gyroscope-gyroscope-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-gyroscope-gyroscope-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=<span class="n">Window</span>]
+<pre class="idl highlight def">[<dfn class="nv idl-code" data-dfn-for="Gyroscope" data-dfn-type="constructor" data-export="" data-lt="Gyroscope(sensorOptions)|Gyroscope()" id="dom-gyroscope-gyroscope"><code>Constructor</code><a class="self-link" href="#dom-gyroscope-gyroscope"></a></dfn>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/accelerometer#dictdef-spatialsensoroptions" id="ref-for-dictdef-spatialsensoroptions">SpatialSensorOptions</a> <dfn class="nv idl-code" data-dfn-for="Gyroscope/Gyroscope(sensorOptions)" data-dfn-type="argument" data-export="" id="dom-gyroscope-gyroscope-sensoroptions-sensoroptions"><code>sensorOptions</code><a class="self-link" href="#dom-gyroscope-gyroscope-sensoroptions-sensoroptions"></a></dfn>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="gyroscope"><code>Gyroscope</code></dfn> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor②">Sensor</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Gyroscope" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-gyroscope-x"><code>x</code></dfn>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Gyroscope" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-gyroscope-y"><code>y</code></dfn>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double②"><span class="kt">double</span></a>? <dfn class="nv dfn-paneled idl-code" data-dfn-for="Gyroscope" data-dfn-type="attribute" data-export="" data-readonly="" data-type="double?" id="dom-gyroscope-z"><code>z</code></dfn>;
 };
 </pre>
-   <p>To <dfn data-dfn-type="dfn" data-noexport="" id="construct-a-gyroscope-object">Construct a Gyroscope Object<a class="self-link" href="#construct-a-gyroscope-object"></a></dfn> the user agent must invoke the <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object" id="ref-for-construct-sensor-object">construct a Sensor object</a> abstract operation.</p>
+   <p>To <dfn data-dfn-type="dfn" data-noexport="" id="construct-a-gyroscope-object">Construct a Gyroscope Object<a class="self-link" href="#construct-a-gyroscope-object"></a></dfn> the user agent must invoke
+the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#construct-spatial-sensor-object" id="ref-for-construct-spatial-sensor-object">construct spatial sensor object</a> abstract operation.</p>
    <h4 class="heading settled" data-level="6.1.1" id="gyroscope-x"><span class="secno">6.1.1. </span><span class="content">Gyroscope.x</span><a class="self-link" href="#gyroscope-x"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-gyroscope-x" id="ref-for-dom-gyroscope-x">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope①">Gyroscope</a></code> interface represents the current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity②">angular velocity</a> around X-axis.
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-gyroscope-x" id="ref-for-dom-gyroscope-x">x</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope②">Gyroscope</a></code> interface represents the current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity②">angular velocity</a> around X-axis.
 In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading">get value from latest reading</a> with <emu-val>this</emu-val> and "x" as arguments.</p>
    <h4 class="heading settled" data-level="6.1.2" id="gyroscope-y"><span class="secno">6.1.2. </span><span class="content">Gyroscope.y</span><a class="self-link" href="#gyroscope-y"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-gyroscope-y" id="ref-for-dom-gyroscope-y">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope②">Gyroscope</a></code> interface represents the current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity③">angular velocity</a> around Y-axis.
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-gyroscope-y" id="ref-for-dom-gyroscope-y">y</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope③">Gyroscope</a></code> interface represents the current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity③">angular velocity</a> around Y-axis.
 In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading①">get value from latest reading</a> with <emu-val>this</emu-val> and "y" as arguments.</p>
    <h4 class="heading settled" data-level="6.1.3" id="gyroscope-z"><span class="secno">6.1.3. </span><span class="content">Gyroscope.z</span><a class="self-link" href="#gyroscope-z"></a></h4>
-   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-gyroscope-z" id="ref-for-dom-gyroscope-z">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope③">Gyroscope</a></code> interface represents the current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity④">angular velocity</a> around Z-axis.
+   <p>The <code class="idl"><a class="idl-code" data-link-type="attribute" href="#dom-gyroscope-z" id="ref-for-dom-gyroscope-z">z</a></code> attribute of the <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope④">Gyroscope</a></code> interface represents the current <a data-link-type="dfn" href="#angular-velocity" id="ref-for-angular-velocity④">angular velocity</a> around Z-axis.
 In other words, this attribute returns the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors/#get-value-from-latest-reading" id="ref-for-get-value-from-latest-reading②">get value from latest reading</a> with <emu-val>this</emu-val> and "z" as arguments.</p>
    <h2 class="heading settled" data-level="7" id="acknowledgements"><span class="secno">7. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
    <p>Tobie Langel for the work on Generic Sensor API.</p>
@@ -1614,7 +1620,6 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
      <li><a href="#gyroscope">(interface)</a><span>, in §6.1</span>
     </ul>
    <li><a href="#dom-gyroscope-gyroscope">Gyroscope(sensorOptions)</a><span>, in §6.1</span>
-   <li><a href="#local-coordinate-system">local coordinate system</a><span>, in §5</span>
    <li><a href="#dom-gyroscope-x">x</a><span>, in §6.1</span>
    <li><a href="#dom-gyroscope-y">y</a><span>, in §6.1</span>
    <li><a href="#dom-gyroscope-z">z</a><span>, in §6.1</span>
@@ -1622,14 +1627,21 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h3 class="no-num no-ref heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
   <ul class="index">
    <li>
+    <a data-link-type="biblio">[accelerometer]</a> defines the following terms:
+    <ul>
+     <li><a href="https://w3c.github.io/accelerometer#dictdef-spatialsensoroptions">SpatialSensorOptions</a>
+     <li><a href="https://w3c.github.io/accelerometer#construct-spatial-sensor-object">construct spatial sensor object</a>
+     <li><a href="https://w3c.github.io/accelerometer#device-coordinate-system">device coordinate system</a>
+     <li><a href="https://w3c.github.io/accelerometer#screen-coordinate-system">screen coordinate system</a>
+    </ul>
+   <li>
     <a data-link-type="biblio">[GENERIC-SENSOR]</a> defines the following terms:
     <ul>
      <li><a href="https://w3c.github.io/sensors/#sensor">Sensor</a>
-     <li><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a>
-     <li><a href="https://w3c.github.io/sensors#construct-sensor-object">construct a sensor object</a>
      <li><a href="https://w3c.github.io/sensors#default-sensor">default sensor</a>
      <li><a href="https://w3c.github.io/sensors/#get-value-from-latest-reading">get value from latest reading</a>
      <li><a href="https://w3c.github.io/sensors#latest-reading">latest reading</a>
+     <li><a href="https://w3c.github.io/sensors#local-coordinate-system">local coordinate system</a>
      <li><a href="https://w3c.github.io/sensors#sensor-type">sensor type</a>
     </ul>
    <li>
@@ -1656,6 +1668,8 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
   <h3 class="no-num no-ref heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
   <dl>
+   <dt id="biblio-accelerometer">[ACCELEROMETER]
+   <dd>Anssi Kostiainen; Alexander Shalamov. <a href="https://w3c.github.io/accelerometer/">Accelerometer</a>. URL: <a href="https://w3c.github.io/accelerometer/">https://w3c.github.io/accelerometer/</a>
    <dt id="biblio-generic-sensor">[GENERIC-SENSOR]
    <dd>Rick Waldron; et al. <a href="https://w3c.github.io/sensors/">Generic Sensor API</a>. URL: <a href="https://w3c.github.io/sensors/">https://w3c.github.io/sensors/</a>
    <dt id="biblio-infra">[INFRA]
@@ -1673,7 +1687,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <dd><a href="http://www.bipm.org/en/publications/si-brochure/">SI Brochure: The International System of Units (SI), 8th edition</a>. 2014. URL: <a href="http://www.bipm.org/en/publications/si-brochure/">http://www.bipm.org/en/publications/si-brochure/</a>
   </dl>
   <h2 class="no-num no-ref heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
-<pre class="idl highlight def">[<a class="nv" href="#dom-gyroscope-gyroscope"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#dictdef-sensoroptions" id="ref-for-dictdef-sensoroptions①">SensorOptions</a> <a class="nv" href="#dom-gyroscope-gyroscope-sensoroptions-sensoroptions"><code>sensorOptions</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>]
+<pre class="idl highlight def">[<a class="nv" href="#dom-gyroscope-gyroscope"><code>Constructor</code></a>(<span class="kt">optional</span> <a class="n" data-link-type="idl-name" href="https://w3c.github.io/accelerometer#dictdef-spatialsensoroptions" id="ref-for-dictdef-spatialsensoroptions①">SpatialSensorOptions</a> <a class="nv" href="#dom-gyroscope-gyroscope-sensoroptions-sensoroptions"><code>sensorOptions</code></a>), <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#SecureContext" id="ref-for-SecureContext①">SecureContext</a>, <a class="nv idl-code" data-link-type="extended-attribute" href="https://heycam.github.io/webidl/#Exposed" id="ref-for-Exposed①">Exposed</a>=<span class="n">Window</span>]
 <span class="kt">interface</span> <a class="nv" href="#gyroscope"><code>Gyroscope</code></a> : <a class="n" data-link-type="idl-name" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor②①">Sensor</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double③"><span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="double?" href="#dom-gyroscope-x"><code>x</code></a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n idl-code" data-link-type="interface" href="https://heycam.github.io/webidl/#idl-double" id="ref-for-idl-double①①"><span class="kt">double</span></a>? <a class="nv" data-readonly="" data-type="double?" href="#dom-gyroscope-y"><code>y</code></a>;
@@ -1696,19 +1710,14 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-angular-velocity④">6.1.3. Gyroscope.z</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="local-coordinate-system">
-   <b><a href="#local-coordinate-system">#local-coordinate-system</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-local-coordinate-system">5. Model</a> <a href="#ref-for-local-coordinate-system①">(2)</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="gyroscope">
    <b><a href="#gyroscope">#gyroscope</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope">5. Model</a>
-    <li><a href="#ref-for-gyroscope①">6.1.1. Gyroscope.x</a>
-    <li><a href="#ref-for-gyroscope②">6.1.2. Gyroscope.y</a>
-    <li><a href="#ref-for-gyroscope③">6.1.3. Gyroscope.z</a>
+    <li><a href="#ref-for-gyroscope①">5.1. Reference Frame</a>
+    <li><a href="#ref-for-gyroscope②">6.1.1. Gyroscope.x</a>
+    <li><a href="#ref-for-gyroscope③">6.1.2. Gyroscope.y</a>
+    <li><a href="#ref-for-gyroscope④">6.1.3. Gyroscope.z</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-gyroscope-x">


### PR DESCRIPTION
The `SpatialSensorOptions` dictionary and the
"construct spatial sensor object" are used, so that
the client can set the local coordinate system for a
Gyroscope instance from the constructor.

This patch is a part of fix for https://github.com/w3c/sensors/issues/257


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pozdnyakov/gyroscope/pull/28.html" title="Last updated on Feb 7, 2018, 8:50 AM GMT (885a8e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/28/172c357...pozdnyakov:885a8e2.html" title="Last updated on Feb 7, 2018, 8:50 AM GMT (885a8e2)">Diff</a>