### PR TITLE
Update the Gyroscope construction

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -166,14 +166,20 @@ Abstract Operations {#abstract-operations}
     : input
     :: |options|, a {{GyroscopeSensorOptions}} object.
     : output
-    :: A {{Sensor}} object.
+    :: A {{Gyroscope}} object.
 
-    1. Let |sensor_instance| be the result of invoking [=construct a Sensor object=] with |options|.
-    1. If |options|.{{referenceFrame!!dict-member}} is "screen", then:
-       1.  Define [=local coordinate system=] for |sensor_instance|
-           as the [=screen coordinate system=].
-    1. Otherwise, define [=local coordinate system=] for |sensor_instance|
-       as the [=device coordinate system=].
+    1.  Let |allowed| be the result of invoking [=check sensor policy-controlled features=]
+        with <a>Gyroscope</a>.
+    1.  If |allowed| is false, then:
+        1.  [=Throw=] a {{SecurityError}} {{DOMException}}.
+    1.  Let |gyroscope| be the new {{Gyroscope}} object.
+    1.  Invoke [=initialize a sensor object=] with |gyroscope| and |options|.
+    1.  If |options|.{{referenceFrame!!dict-member}} is "screen", then:
+        1.  Define [=local coordinate system=] for |gyroscope|
+            as the [=screen coordinate system=].
+    1.  Otherwise, define [=local coordinate system=] for |gyroscope|
+        as the [=device coordinate system=].
+    1.  Return |gyroscope|.
 </div>
 
 Acknowledgements {#acknowledgements}

--- a/index.html
+++ b/index.html
@@ -1183,7 +1183,7 @@ Possible extra rowspan handling
       background-attachment: fixed;
     }
   </style>
-  <meta content="Bikeshed version 166744eb86a34dbc5493268ea410dc65275aa964" name="generator">
+  <meta content="Bikeshed version ae5d415446a9edf0c07d32303ac1d21767d86d57" name="generator">
   <link href="http://www.w3.org/TR/gyroscope/" rel="canonical">
 <style>/* style-md-lists */
 
@@ -1431,7 +1431,7 @@ pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Gyroscope</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-08">8 February 2018</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2018-02-19">19 February 2018</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1607,19 +1607,31 @@ In other words, this attribute returns the result of invoking <a data-link-type=
       <p><var>options</var>, a <code class="idl"><a data-link-type="idl" href="#dictdef-gyroscopesensoroptions" id="ref-for-dictdef-gyroscopesensoroptions①">GyroscopeSensorOptions</a></code> object.</p>
      <dt data-md="">output
      <dd data-md="">
-      <p>A <code class="idl"><a data-link-type="idl" href="https://w3c.github.io/sensors/#sensor" id="ref-for-sensor③">Sensor</a></code> object.</p>
+      <p>A <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope⑥">Gyroscope</a></code> object.</p>
     </dl>
     <ol>
      <li data-md="">
-      <p>Let <var>sensor_instance</var> be the result of invoking <a data-link-type="dfn" href="https://w3c.github.io/sensors#construct-sensor-object" id="ref-for-construct-sensor-object">construct a Sensor object</a> with <var>options</var>.</p>
+      <p>Let <var>allowed</var> be the result of invoking <a data-link-type="dfn">check sensor policy-controlled features</a> with <a data-link-type="dfn" href="#gyroscope-sensor-type" id="ref-for-gyroscope-sensor-type③">Gyroscope</a>.</p>
+     <li data-md="">
+      <p>If <var>allowed</var> is false, then:</p>
+      <ol>
+       <li data-md="">
+        <p><a data-link-type="dfn" href="https://heycam.github.io/webidl/#dfn-throw" id="ref-for-dfn-throw">Throw</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror" id="ref-for-securityerror">SecurityError</a></code> <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#idl-DOMException" id="ref-for-idl-DOMException">DOMException</a></code>.</p>
+      </ol>
+     <li data-md="">
+      <p>Let <var>gyroscope</var> be the new <code class="idl"><a data-link-type="idl" href="#gyroscope" id="ref-for-gyroscope⑦">Gyroscope</a></code> object.</p>
+     <li data-md="">
+      <p>Invoke <a data-link-type="dfn">initialize a sensor object</a> with <var>gyroscope</var> and <var>options</var>.</p>
      <li data-md="">
       <p>If <var>options</var>.<code class="idl"><a class="idl-code" data-link-type="dict-member" href="#dom-gyroscopesensoroptions-referenceframe" id="ref-for-dom-gyroscopesensoroptions-referenceframe">referenceFrame</a></code> is "screen", then:</p>
       <ol>
        <li data-md="">
-        <p>Define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> for <var>sensor_instance</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system①">screen coordinate system</a>.</p>
+        <p>Define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system③">local coordinate system</a> for <var>gyroscope</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#screen-coordinate-system" id="ref-for-screen-coordinate-system①">screen coordinate system</a>.</p>
       </ol>
      <li data-md="">
-      <p>Otherwise, define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system④">local coordinate system</a> for <var>sensor_instance</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system①">device coordinate system</a>.</p>
+      <p>Otherwise, define <a data-link-type="dfn" href="https://w3c.github.io/sensors#local-coordinate-system" id="ref-for-local-coordinate-system④">local coordinate system</a> for <var>gyroscope</var> as the <a data-link-type="dfn" href="https://w3c.github.io/accelerometer#device-coordinate-system" id="ref-for-device-coordinate-system①">device coordinate system</a>.</p>
+     <li data-md="">
+      <p>Return <var>gyroscope</var>.</p>
     </ol>
    </div>
    <h2 class="heading settled" data-level="8" id="acknowledgements"><span class="secno">8. </span><span class="content">Acknowledgements</span><a class="self-link" href="#acknowledgements"></a></h2>
@@ -1678,7 +1690,6 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <ul>
      <li><a href="https://w3c.github.io/sensors/#sensor">Sensor</a>
      <li><a href="https://w3c.github.io/sensors/#dictdef-sensoroptions">SensorOptions</a>
-     <li><a href="https://w3c.github.io/sensors#construct-sensor-object">construct a sensor object</a>
      <li><a href="https://w3c.github.io/sensors#default-sensor">default sensor</a>
      <li><a href="https://w3c.github.io/sensors/#get-value-from-latest-reading">get value from latest reading</a>
      <li><a href="https://w3c.github.io/sensors#latest-reading">latest reading</a>
@@ -1702,9 +1713,12 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <li>
     <a data-link-type="biblio">[WEBIDL]</a> defines the following terms:
     <ul>
+     <li><a href="https://heycam.github.io/webidl/#idl-DOMException">DOMException</a>
      <li><a href="https://heycam.github.io/webidl/#Exposed">Exposed</a>
      <li><a href="https://heycam.github.io/webidl/#SecureContext">SecureContext</a>
+     <li><a href="https://heycam.github.io/webidl/#securityerror">SecurityError</a>
      <li><a href="https://heycam.github.io/webidl/#idl-double">double</a>
+     <li><a href="https://heycam.github.io/webidl/#dfn-throw">throw</a>
     </ul>
   </ul>
   <h2 class="no-num no-ref heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
@@ -1747,6 +1761,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
    <b><a href="#gyroscope-sensor-type">#gyroscope-sensor-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-gyroscope-sensor-type">5. Model</a> <a href="#ref-for-gyroscope-sensor-type①">(2)</a> <a href="#ref-for-gyroscope-sensor-type②">(3)</a>
+    <li><a href="#ref-for-gyroscope-sensor-type③">7.1. Construct a Gyroscope object</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="angular-velocity">
@@ -1767,6 +1782,7 @@ conforming IDL fragments, as described in the Web IDL specification. <a data-lin
     <li><a href="#ref-for-gyroscope③">6.1.1. Gyroscope.x</a>
     <li><a href="#ref-for-gyroscope④">6.1.2. Gyroscope.y</a>
     <li><a href="#ref-for-gyroscope⑤">6.1.3. Gyroscope.z</a>
+    <li><a href="#ref-for-gyroscope⑥">7.1. Construct a Gyroscope object</a> <a href="#ref-for-gyroscope⑦">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-gyroscope-x">


### PR DESCRIPTION
Update the "construct a gyroscope object" abstract operation,
so that it corresponds to https://github.com/w3c/sensors/pull/345


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pozdnyakov/gyroscope/pull/31.html" title="Last updated on Feb 19, 2018, 2:12 PM GMT (e410a0b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/31/b1f3668...pozdnyakov:e410a0b.html" title="Last updated on Feb 19, 2018, 2:12 PM GMT (e410a0b)">Diff</a>