### PR TITLE
Remove extra whitespace in IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -166,7 +166,7 @@ The Gyroscope Interface {#gyroscope-interface}
 
   enum GyroscopeLocalCoordinateSystem { "device", "screen" };
 
-  dictionary GyroscopeSensorOptions : SensorOptions  {
+  dictionary GyroscopeSensorOptions : SensorOptions {
     GyroscopeLocalCoordinateSystem referenceFrame = "device";
   };
 </pre>


### PR DESCRIPTION
Discovered by https://github.com/w3c/web-platform-tests/pull/9791.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/gyroscope/pull/35.html" title="Last updated on Mar 2, 2018, 11:15 PM GMT (848a5ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/35/dc8a56a...foolip:848a5ef.html" title="Last updated on Mar 2, 2018, 11:15 PM GMT (848a5ef)">Diff</a>