### PR TITLE
Make default allowlist normative

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -132,6 +132,8 @@ The <a>Gyroscope</a> has a <a>default sensor</a>, which is the device's main gyr
 
 The <a>Gyroscope</a> has an associated [=sensor permission name=] which is <a for="PermissionName" enum-value>"gyroscope"</a>.
 
+The <a>Gyroscope</a> is a [=policy-controlled feature=] identified by the string "gyroscope". Its [=default allowlist=] is `'self'`.
+
 A [=latest reading=] of a {{Sensor}} of <a>Gyroscope</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain current <a>angular
 velocity</a> about the corresponding axes.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/pull/46.html" title="Last updated on Sep 1, 2021, 3:18 PM UTC (fa90254)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/46/9e5d9a5...fa90254.html" title="Last updated on Sep 1, 2021, 3:18 PM UTC (fa90254)">Diff</a>