### PR TITLE
Update stability status in SOTD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -22,6 +22,7 @@ Boilerplate: omit issues-index, omit conformance, repository-issue-tracking no
 Include MDN Panels: if possible
 Implementation Report: https://www.w3.org/wiki/DAS/Implementations
 Default Biblio Status: current
+Status Text: This document is maintained and updated at any time. Some parts of this document are work in progress.
 </pre>
 <pre class="anchors">
 urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR


### PR DESCRIPTION
Required to pass specberus sotd.draft-stability test and to unblock TR publication.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/pull/48.html" title="Last updated on Dec 3, 2021, 11:22 AM UTC (957295c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/48/614d1c6...957295c.html" title="Last updated on Dec 3, 2021, 11:22 AM UTC (957295c)">Diff</a>