### PR TITLE
editorial: Remove "sensor reading" custom anchor.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -32,7 +32,6 @@ urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
     text: default sensor
     text: sensor type
     text: local coordinate system
-    text: sensor reading
     text: sensor permission name; url: sensor-permission-names
     text: location tracking; url: location-tracking
     text: keylogging; url: keystroke-monitoring


### PR DESCRIPTION
w3c/sensors#456 started exporting the definition, so there is no need to
have a custom anchor anymore.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/gyroscope/pull/50.html" title="Last updated on Jan 30, 2023, 10:28 AM UTC (0e53808)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/50/0f01710...rakuco:0e53808.html" title="Last updated on Jan 30, 2023, 10:28 AM UTC (0e53808)">Diff</a>