### PR TITLE
Rewrite Automation section after w3c/sensors#470

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -40,9 +40,6 @@ urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
     text: eavesdropping; url: eavesdropping
     text: generic mitigations; url: mitigation-strategies
     text: supported sensor options
-    text: automation
-    text: mock sensor type
-    text: mock sensor reading values
 urlPrefix: https://w3c.github.io/accelerometer/; spec: ACCELEROMETER
   type: dfn
     text: device coordinate system
@@ -241,23 +238,13 @@ Abstract Operations {#abstract-operations}
 
 Automation {#automation}
 ==========
-This section extends the [=automation=] section defined in the Generic Sensor API [[GENERIC-SENSOR]]
-to provide mocking information about the rate of rotation around the device's local three primary axes
-for the purposes of testing a user agent's implementation of {{Gyroscope}} API.
+This section extends [[GENERIC-SENSOR#automation]] by providing [=Gyroscope=]-specific virtual sensor metadata.
 
-<h3 id="mock-gyroscope-type">Mock Sensor Type</h3>
-
-The {{Gyroscope}} class has an associated [=mock sensor type=] which is
-<a for="MockSensorType" enum-value>"gyroscope"</a>, its [=mock sensor reading values=]
-dictionary is defined as follows:
-
-<pre class="idl">
-  dictionary GyroscopeReadingValues {
-    required double? x;
-    required double? y;
-    required double? z;
-  };
-</pre>
+The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
+: [=map/key=]
+:: "`gyroscope`"
+: [=map/value=]
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Gyroscope=] and [=reading parsing algorithm=] is [=parse xyz reading=].
 
 Acknowledgements {#acknowledgements}
 ================


### PR DESCRIPTION
The Automation section in the Generic Sensor API specification was rewritten and several terms and concepts have changed.

This commit adapts the Gyroscope spec to the changes:
* Remove references to "mock sensor type", "mock sensor reading values" and the "MockSensorType" enum.
* Define an entry in the per-type virtual sensor metadata map whose key is what used to be the "gyroscope" entry in MockSensorType and an appropriate virtual sensor metadata entry.

This is enough to integrate properly with the Generic Sensor spec and allow Gyroscope virtual sensors to be created and used.

Fixes #51.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/gyroscope/pull/52.html" title="Last updated on Oct 17, 2023, 10:22 AM UTC (537f841)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/52/0d5f8b1...rakuco:537f841.html" title="Last updated on Oct 17, 2023, 10:22 AM UTC (537f841)">Diff</a>