### PR TITLE
editorial: Add an empty line after the "Automation" header

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -238,6 +238,7 @@ Abstract Operations {#abstract-operations}
 
 Automation {#automation}
 ==========
+
 This section extends [[GENERIC-SENSOR#automation]] by providing [=Gyroscope=]-specific virtual sensor metadata.
 
 The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:


### PR DESCRIPTION
Follow-up to #52: the lack of the empty line there causes Bikeshed not to add the required `<p>` tags to the paragraphs in the section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/gyroscope/pull/53.html" title="Last updated on Oct 20, 2023, 10:49 AM UTC (b77bddb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/53/62c9f1e...rakuco:b77bddb.html" title="Last updated on Oct 20, 2023, 10:49 AM UTC (b77bddb)">Diff</a>