### PR TITLE
Remove "sensor permission name" custom anchor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -32,7 +32,6 @@ urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR
     text: default sensor
     text: sensor type
     text: local coordinate system
-    text: sensor permission name; url: sensor-permission-names
     text: location tracking; url: location-tracking
     text: keylogging; url: keystroke-monitoring
     text: fingerprinting; url: device-fingerprinting


### PR DESCRIPTION
The Generic Sensor API already exports the definition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/gyroscope/pull/54.html" title="Last updated on Oct 24, 2023, 3:28 PM UTC (189287b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/54/d6809bb...rakuco:189287b.html" title="Last updated on Oct 24, 2023, 3:28 PM UTC (189287b)">Diff</a>