### PR TITLE
Modernize Gyroscope constructor steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -180,8 +180,9 @@ The Gyroscope Interface {#gyroscope-interface}
   };
 </pre>
 
-To construct a {{Gyroscope}} object the user agent must invoke
-the [=construct a gyroscope object=] abstract operation.
+<div algorithm>
+The <dfn constructor for="Gyroscope" lt="Gyroscope(sensorOptions)"><code>new Gyroscope(|sensorOptions|)</code></dfn> constructor steps are to invoke the [=construct a gyroscope object=] abstract operation with [=this=] and |sensorOptions|.
+</div>
 
 [=Supported sensor options=] for {{Gyroscope}} are
 "frequency" and "referenceFrame".
@@ -218,22 +219,17 @@ Abstract Operations {#abstract-operations}
 <div algorithm="construct a gyroscope object">
 
     : input
+    :: |object|, a {{Gyroscope}} object.
     :: |options|, a {{GyroscopeSensorOptions}} object.
-    : output
-    :: A {{Gyroscope}} object.
 
     1.  Let |allowed| be the result of invoking [=check sensor policy-controlled features=]
-        with <a>Gyroscope</a>.
+        with |object|'s [=sensor type=].
     1.  If |allowed| is false, then:
         1.  [=Throw=] a {{SecurityError}} {{DOMException}}.
-    1.  Let |gyroscope| be the new {{Gyroscope}} object.
-    1.  Invoke [=initialize a sensor object=] with |gyroscope| and |options|.
+    1.  Invoke [=initialize a sensor object=] with |object| and |options|.
     1.  If |options|.{{referenceFrame!!dict-member}} is "screen", then:
-        1.  Define [=local coordinate system=] for |gyroscope|
-            as the [=screen coordinate system=].
-    1.  Otherwise, define [=local coordinate system=] for |gyroscope|
-        as the [=device coordinate system=].
-    1.  Return |gyroscope|.
+        1.  Set |object|'s [=local coordinate system=] to the [=screen coordinate system=].
+    1.  Otherwise, define |object|'s [=local coordinate system=] to the [=device coordinate system=].
 </div>
 
 Automation {#automation}


### PR DESCRIPTION
Adapt to Web IDL's current practices and be less hand-wavy when constructing
a Gyroscope instance:
- We are given `this` so we do not need to say "let foo be a new instance of
  IDLInterface".
- Similarly, there is no need to return anything from the "construct a
  gyroscope object" operation, it is only supposed to either initialize
  `this` or throw an exception.
- Pass the right argument with the right type to "check sensor
  policy-controlled features".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/gyroscope/pull/55.html" title="Last updated on Oct 24, 2023, 3:29 PM UTC (070547c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/55/d6809bb...rakuco:070547c.html" title="Last updated on Oct 24, 2023, 3:29 PM UTC (070547c)">Diff</a>