### PR TITLE
Clean up Model section, export permission and policy-controlled feature name

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -120,20 +120,26 @@ inertial sensors are in use and/or require explicit user consent to access [=sen
 These mitigation strategies complement the [=generic mitigations=] defined
 in the Generic Sensor API [[!GENERIC-SENSOR]].
 
+Permissions Policy integration {#permissions-policy-integration}
+==============================
+
+This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn data-lt="gyroscope-feature" export>gyroscope</dfn></code>". Its [=default allowlist=] is "`self`".
+
 Model {#model}
 =====
 
-The <dfn id="gyroscope-sensor-type">Gyroscope</dfn> <a>sensor type</a>'s associated {{Sensor}} subclass is the {{Gyroscope}} class.
+The <dfn id="gyroscope-sensor-type">Gyroscope</dfn> <a>sensor type</a> has the following associated data:
 
-The <a>Gyroscope</a> has a <a>default sensor</a>, which is the device's main gyroscope sensor.
-
-The <a>Gyroscope</a> is a [=powerful feature=] that is identified by the
-[=powerful feature/name=] "gyroscope", which is also its associated
-[=sensor permission name=]. Its [=powerful feature/permission revocation algorithm=] is the
-result of calling the [=generic sensor permission revocation algorithm=] with
-"gyroscope".
-
-The <a>Gyroscope</a> is a [=policy-controlled feature=] identified by the string "gyroscope". Its [=default allowlist=] is `'self'`.
+ : [=Extension sensor interface=]
+ :: {{Gyroscope}}
+ : [=Sensor permission names=]
+ :: "<code><dfn permission export>gyroscope</dfn></code>"
+ : [=Sensor feature names=]
+ :: "[=gyroscope-feature|gyroscope=]"
+ : [=powerful feature/Permission revocation algorithm=]
+ :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>gyroscope</a></code>".
+ : [=Default sensor=]
+ :: The device's main gyroscope sensor.
 
 A [=latest reading=] of a {{Sensor}} of <a>Gyroscope</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain current <a>angular


### PR DESCRIPTION
* Move the permissions-policy text to a separate section for clarity.
* Stop saying "Gyroscope a policy-controlled feature" because it does not
  make much sense. The most common way to list features is by saying
  something like "this spec defines a feature identifed by the string
  'foo'". In our case, that string is "gyroscope".
* Define and export the feature identifier above, as it is used in e.g. the
  Orientation Sensor specification.
* Explicitly list all data associated with the spec's sensor type using a
  definition list instead of a very long paragraph.
* Similarly to w3c/accelerometer#67, define and export the "gyroscope"
  permission so that we can eventually link to the permission name from
  https://w3c.github.io/permissions-registry/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/gyroscope/pull/56.html" title="Last updated on Oct 24, 2023, 3:29 PM UTC (75a8439)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/56/d6809bb...rakuco:75a8439.html" title="Last updated on Oct 24, 2023, 3:29 PM UTC (75a8439)">Diff</a>