### PR TITLE
Adapt to virtual sensor changes in w3c/sensors#475

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -139,6 +139,8 @@ The <dfn id="gyroscope-sensor-type">Gyroscope</dfn> <a>sensor type</a> has the f
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>gyroscope</a></code>".
  : [=Default sensor=]
  :: The device's main gyroscope sensor.
+ : [=Virtual sensor type=]
+ :: "<code><dfn data-lt="gyroscope virtual sensor type">gyroscope</dfn></code>"
 
 A [=latest reading=] of a {{Sensor}} of <a>Gyroscope</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain current <a>angular
@@ -244,9 +246,9 @@ This section extends [[GENERIC-SENSOR#automation]] by providing [=Gyroscope=]-sp
 
 The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
 : [=map/key=]
-:: "`gyroscope`"
+:: "<code>[=gyroscope virtual sensor type|gyroscope=]</code>"
 : [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/virtual sensor type=] is [=Gyroscope=] and [=reading parsing algorithm=] is [=parse xyz reading=].
+:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/reading parsing algorithm=] is [=parse xyz reading=].
 
 Acknowledgements {#acknowledgements}
 ================


### PR DESCRIPTION
w3c/sensors#475 removed the "virtual sensor type" item from the "virtual
sensor metadata" struct and turned it into a string that is referenced from
the automation bits as well as (optionally) defined by a sensor type.

Adapt to it here by removing mentions of `[=virtual sensor metadata/virtual
sensor type=]` from the spec and adding virtual sensor types to each sensor
type defined here.

Fixes #58.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/gyroscope/pull/57.html" title="Last updated on Dec 5, 2023, 4:43 PM UTC (22d42f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/57/153424c...rakuco:22d42f9.html" title="Last updated on Dec 5, 2023, 4:43 PM UTC (22d42f9)">Diff</a>