### PR TITLE
editorial: Use permissions and permissions-policy dfn's from DEVICE-ORIENTATION

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -44,6 +44,10 @@ urlPrefix: https://w3c.github.io/accelerometer/; spec: ACCELEROMETER
     text: device coordinate system
     text: screen coordinate system
 </pre>
+<pre class=link-defaults>
+spec:orientation-event; type:dfn; text:gyroscope-feature
+spec:orientation-event; type:permission; text:gyroscope
+</pre>
 
 <pre class=biblio>
 {
@@ -122,7 +126,7 @@ in the Generic Sensor API [[!GENERIC-SENSOR]].
 Permissions Policy integration {#permissions-policy-integration}
 ==============================
 
-This specification defines a [=policy-controlled feature=] identified by the string "<code><dfn data-lt="gyroscope-feature" export>gyroscope</dfn></code>". Its [=default allowlist=] is "`self`".
+This specification utilizes the [=policy-controlled feature=] identified by the string "<code><a data-lt="gyroscope-feature">gyroscope</a></code>" defined in [[DEVICE-ORIENTATION]].
 
 Model {#model}
 =====
@@ -132,9 +136,9 @@ The <dfn id="gyroscope-sensor-type">Gyroscope</dfn> <a>sensor type</a> has the f
  : [=Extension sensor interface=]
  :: {{Gyroscope}}
  : [=Sensor permission names=]
- :: "<code><dfn permission export>gyroscope</dfn></code>"
+ :: "<code><a permission>gyroscope</a></code>" (defined in [[DEVICE-ORIENTATION]])
  : [=Sensor feature names=]
- :: "[=gyroscope-feature|gyroscope=]"
+ :: "[=gyroscope-feature|gyroscope=]" (defined in [[DEVICE-ORIENTATION]])
  : [=powerful feature/Permission revocation algorithm=]
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>gyroscope</a></code>".
  : [=Default sensor=]


### PR DESCRIPTION
Adapt to w3c/deviceorientation#121 and w3c/deviceorientation#123.

Those two PRs have moved the definition of the "gyroscope"
permission name and permissions policy token to the Device Orientation
spec, which is more widely implemented than this specification and can
be referenced from this one.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakuco/gyroscope/pull/59.html" title="Last updated on Jan 4, 2024, 3:33 PM UTC (1f2213e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/59/ccb15d7...rakuco:1f2213e.html" title="Last updated on Jan 4, 2024, 3:33 PM UTC (1f2213e)">Diff</a>