### PR TITLE
editorial: Use "gyroscope virtual sensor type" dfn from DEVICE-ORIENTATION

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -144,7 +144,7 @@ The <dfn id="gyroscope-sensor-type">Gyroscope</dfn> <a>sensor type</a> has the f
  : [=Default sensor=]
  :: The device's main gyroscope sensor.
  : [=Virtual sensor type=]
- :: "<code><dfn data-lt="gyroscope virtual sensor type">gyroscope</dfn></code>"
+ :: "<code><a data-lt="gyroscope virtual sensor type">gyroscope</a></code>"
 
 A [=latest reading=] of a {{Sensor}} of <a>Gyroscope</a> <a>sensor type</a> includes three [=map/entries=]
 whose [=map/keys=] are "x", "y", "z" and whose [=map/values=] contain current <a>angular
@@ -248,11 +248,7 @@ Automation {#automation}
 
 This section extends [[GENERIC-SENSOR#automation]] by providing [=Gyroscope=]-specific virtual sensor metadata.
 
-The [=per-type virtual sensor metadata=] [=map=] must have the following [=map/entry=]:
-: [=map/key=]
-:: "<code>[=gyroscope virtual sensor type|gyroscope=]</code>"
-: [=map/value=]
-:: A [=virtual sensor metadata=] whose [=virtual sensor metadata/reading parsing algorithm=] is [=parse xyz reading=].
+The [=gyroscope virtual sensor type=] and its corresponding entry in the [=per-type virtual sensor metadata=] [=map=] are defined in [[DEVICE-ORIENTATION#automation]].
 
 Acknowledgements {#acknowledgements}
 ================


### PR DESCRIPTION
Adapt to w3c/deviceorientation#124, which added and exported a `dfn` for
"gyroscope virtual sensor type" to be shared by that specification and this
one.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/pull/61.html" title="Last updated on Jan 8, 2024, 8:48 AM UTC (b518cae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/61/032d4d9...b518cae.html" title="Last updated on Jan 8, 2024, 8:48 AM UTC (b518cae)">Diff</a>