### PR TITLE
Update permission name and feature name references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -44,11 +44,6 @@ urlPrefix: https://w3c.github.io/accelerometer/; spec: ACCELEROMETER
     text: device coordinate system
     text: screen coordinate system
 </pre>
-<pre class=link-defaults>
-spec:orientation-event; type:dfn; text:gyroscope-feature
-spec:orientation-event; type:permission; text:gyroscope
-</pre>
-
 <pre class=biblio>
 {
     "KEYSTROKEDEFENSE": {
@@ -126,7 +121,7 @@ in the Generic Sensor API [[!GENERIC-SENSOR]].
 Permissions Policy integration {#permissions-policy-integration}
 ==============================
 
-This specification utilizes the [=policy-controlled feature=] identified by the string "<code><a data-lt="gyroscope-feature">gyroscope</a></code>" defined in [[DEVICE-ORIENTATION]].
+This specification utilizes the [=policy-controlled feature=] identified by the string "<code><a permission>gyroscope</a></code>" defined in [[DEVICE-ORIENTATION]].
 
 Model {#model}
 =====
@@ -136,9 +131,9 @@ The <dfn id="gyroscope-sensor-type">Gyroscope</dfn> <a>sensor type</a> has the f
  : [=Extension sensor interface=]
  :: {{Gyroscope}}
  : [=Sensor permission names=]
- :: "<code><a permission>gyroscope</a></code>" (defined in [[DEVICE-ORIENTATION]])
+ :: "<code><a permission>gyroscope</a></code>"
  : [=Sensor feature names=]
- :: "[=gyroscope-feature|gyroscope=]" (defined in [[DEVICE-ORIENTATION]])
+ :: <a permission>"gyroscope"</a>
  : [=powerful feature/Permission revocation algorithm=]
  :: Invoke the [=generic sensor permission revocation algorithm=] with "<code><a permission>gyroscope</a></code>".
  : [=Default sensor=]


### PR DESCRIPTION
The permission names are shared across Permissions and Permissions Policy specs: https://www.w3.org/TR/permissions/#relationship-to-permissions-policy

Similar to https://github.com/w3c/accelerometer/pull/80


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/pull/63.html" title="Last updated on Oct 8, 2024, 10:59 AM UTC (5f8b037)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/63/97e6224...5f8b037.html" title="Last updated on Oct 8, 2024, 10:59 AM UTC (5f8b037)">Diff</a>