### PR TITLE
Add SotD implementation status advisement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -24,9 +24,8 @@ Implementation Report: https://www.w3.org/wiki/DAS/Implementations
 Default Biblio Status: current
 Status Text: <div class="advisement">
   This specification is currently implemented in a single browser engine (Blink).
-  The <a href="https://www.w3.org/TR/device-orientation/">Device Orientation and Motion</a>
-  specification provides equivalent functionality and is implemented across major browser engines.
-  This specification is being maintained to support existing deployed content.
+  The [[DEVICE-ORIENTATION]] specification provides equivalent functionality and is implemented across major browser engines.
+  This specification is being maintained while websites migrate to [[DEVICE-ORIENTATION]].
   Implementer standards positions:
   <a href="https://github.com/WebKit/standards-positions/issues/347">WebKit</a>,
   <a href="https://github.com/mozilla/standards-positions/issues/35">Mozilla</a>.

--- a/index.bs
+++ b/index.bs
@@ -22,7 +22,15 @@ Boilerplate: omit issues-index, omit conformance, repository-issue-tracking no
 Include MDN Panels: if possible
 Implementation Report: https://www.w3.org/wiki/DAS/Implementations
 Default Biblio Status: current
-Status Text: This document is maintained and updated at any time. Some parts of this document are work in progress.
+Status Text: <div class="advisement">
+  This specification is currently implemented in a single browser engine (Blink).
+  The <a href="https://www.w3.org/TR/device-orientation/">Device Orientation and Motion</a>
+  specification provides equivalent functionality and is implemented across major browser engines.
+  This specification is being maintained to support existing deployed content.
+  Implementer standards positions:
+  <a href="https://github.com/WebKit/standards-positions/issues/347">WebKit</a>,
+  <a href="https://github.com/mozilla/standards-positions/issues/35">Mozilla</a>.
+  </div>
 </pre>
 <pre class="anchors">
 urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR


### PR DESCRIPTION
Adds a `.advisement` box to the Status of This Document section to signal implementation status to developers at a glance.

Per TAG requirement ([w3ctag/design-reviews#1187](https://github.com/w3ctag/design-reviews/issues/1187#issuecomment-3889788860)):

> At a minimum, each document's support level should be in its SotD section, but ideally the WG would find a way to ensure that developers reading a specification can tell at a glance which kind of document they're reading.

All implementation status claims are verified against MDN BCD. Standards position URLs are verified against the live issues.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/gyroscope/pull/65.html" title="Last updated on Mar 31, 2026, 4:56 AM UTC (d1c2b5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/65/b1bf843...marcoscaceres:d1c2b5c.html" title="Last updated on Mar 31, 2026, 4:56 AM UTC (d1c2b5c)">Diff</a>