### PR TITLE
Add implementation status note to SotD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -22,7 +22,10 @@ Boilerplate: omit issues-index, omit conformance, repository-issue-tracking no
 Include MDN Panels: if possible
 Implementation Report: https://www.w3.org/wiki/DAS/Implementations
 Default Biblio Status: current
-Status Text: This document is maintained and updated at any time. Some parts of this document are work in progress.
+Status Text:
+  <p class="advisement">This specification is maintained for existing deployments. Multiple browser engines have expressed concerns about this specification. For new projects, developers should use <a href="https://www.w3.org/TR/orientation-event/">Device Orientation and Motion</a>, which has cross-engine support. The Working Group intends to develop new motion-sensing functionality in <a href="https://www.w3.org/TR/orientation-event/">Device Orientation and Motion</a>.</p>
+
+  This document is maintained and updated at any time. Some parts of this document are work in progress.
 </pre>
 <pre class="anchors">
 urlPrefix: https://w3c.github.io/sensors/; spec: GENERIC-SENSOR


### PR DESCRIPTION
Addresses the TAG's 'at a glance' concern in design-reviews#1187.

The paragraph uses `<p class="advisement">` so it renders as a highlighted box, making the implementation-status signal visible at a glance rather than blending into the SotD boilerplate.

Reviewed in fork by @marcoscaceres and @jyasskin: https://github.com/christianliebel/gyroscope/pull/1


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/christianliebel/gyroscope/pull/66.html" title="Last updated on May 14, 2026, 11:47 AM UTC (46c8f01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/gyroscope/66/b1bf843...christianliebel:46c8f01.html" title="Last updated on May 14, 2026, 11:47 AM UTC (46c8f01)">Diff</a>